### PR TITLE
bugfix/bt-59_filter-adjust

### DIFF
--- a/src/components/ui/filter-bar/filter-bar.tsx
+++ b/src/components/ui/filter-bar/filter-bar.tsx
@@ -15,7 +15,7 @@ const FilterBar = () => {
 
   const handleFilterClick = (filter: FilterType) => {
     toggleFilter(filter);
-    window.scrollTo({ top: 0 });
+    window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   return (


### PR DESCRIPTION
feat(home-page): actualizar la lógica de filtrado de posts; se eliminan los percentiles y se implementa un ordenamiento directo según los filtros activos, mejorando la experiencia de usuario. Además, se añade un desplazamiento suave al hacer clic en los filtros.